### PR TITLE
Add microservices flashcards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ Prefer a browser? Import the repo into Overleaf and press *Re-compile* – Overl
 ```
 .
 ├── areas/
-│   ├── csharp-language-beginner.tex
-│   ├── csharp-language-middle.tex
-│   ├── csharp-language-advanced.tex
-│   ├── threading-async-await.tex
-│   ├── design-principles.tex
-│   ├── design-patterns.tex
-│   ├── entity-framework.tex
-│   └── linq.tex
+│   ├── 1-csharp-language-beginner.tex
+│   ├── 2-csharp-language-middle.tex
+│   ├── 3-csharp-language-advance.tex
+│   ├── 4-LINQ.tex
+│   ├── 5-threading-async-await.tex
+│   ├── 6-entity-framework.tex
+│   ├── 7-design-principles.tex
+│   ├── 8-design-patterns.tex
+│   ├── 9-OAuth.tex
+│   └── 10-microservices.tex
 ├── main.tex
 ├── mybeamer.cls / mybeamer.sty
 └── .github/workflows/ci.yml

--- a/areas/10-microservices.tex
+++ b/areas/10-microservices.tex
@@ -1,0 +1,132 @@
+% Microservices section
+
+% 1 – Bulkhead Pattern
+\QuestionSlide[\CategoryBadge[MicroColor!20]{Microservices}]{** What is the Bulkhead Pattern?}
+
+\begin{frame}[fragile]
+  \frametitle{%
+    \begin{tikzpicture}[remember picture, overlay]
+      \node[anchor=north east, xshift=-0.4cm, yshift=-0.4cm, text=black] at (current page.north east) {
+        \CategoryBadge[MicroColor!20]{Microservices}
+      };
+    \end{tikzpicture}
+    Answer \theqcounter: What is the Bulkhead Pattern?%
+  }
+
+  {\footnotesize
+  The Bulkhead Pattern isolates critical resources (threads, connections) into independent pools so that a failure in one area does not bring down the entire system.
+  }
+
+  \begin{minted}[fontsize=\scriptsize]{csharp}
+var bulkhead = Policy.BulkheadAsync<HttpResponseMessage>(
+    maxParallelization: 50,
+    maxQueuingActions: 100);
+await bulkhead.ExecuteAsync(() => httpClient.GetAsync(url));
+  \end{minted}
+\end{frame}
+
+% 2 – Sidecar Pattern
+\QuestionSlide[\CategoryBadge[MicroColor!20]{Microservices}]{* What is the Sidecar Pattern?}
+
+\begin{frame}[fragile]
+  \frametitle{%
+    \begin{tikzpicture}[remember picture, overlay]
+      \node[anchor=north east, xshift=-0.4cm, yshift=-0.4cm, text=black] at (current page.north east) {
+        \CategoryBadge[MicroColor!20]{Microservices}
+      };
+    \end{tikzpicture}
+    Answer \theqcounter: What is the Sidecar Pattern?%
+  }
+
+  {\footnotesize
+  The Sidecar Pattern deploys a helper service alongside the main service within the same host or pod. The sidecar handles cross-cutting concerns like logging or proxying without modifying the primary service.
+  }
+
+  \begin{minted}[fontsize=\scriptsize]{yaml}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+  - name: web
+    image: myapi:1.0
+  - name: logger
+    image: fluentd:latest
+  \end{minted}
+\end{frame}
+
+% 3 – Service Mesh
+\QuestionSlide[\CategoryBadge[MicroColor!20]{Microservices}]{** What is a Service Mesh?}
+
+\begin{frame}[fragile]
+  \frametitle{%
+    \begin{tikzpicture}[remember picture, overlay]
+      \node[anchor=north east, xshift=-0.4cm, yshift=-0.4cm, text=black] at (current page.north east) {
+        \CategoryBadge[MicroColor!20]{Microservices}
+      };
+    \end{tikzpicture}
+    Answer \theqcounter: What is a Service Mesh?%
+  }
+
+  {\footnotesize
+  A Service Mesh is an infrastructure layer that manages service-to-service communication via sidecar proxies, providing features like traffic routing, retries, and observability without changing application code. Popular meshes include Istio and Linkerd.
+  }
+
+  \begin{minted}[fontsize=\scriptsize]{bash}
+# Enable Istio sidecar injection
+kubectl label namespace default istio-injection=enabled
+  \end{minted}
+\end{frame}
+
+% 4 – Strangler Fig Pattern
+\QuestionSlide[\CategoryBadge[MicroColor!20]{Microservices}]{* What is the Strangler Fig Pattern?}
+
+\begin{frame}[fragile]
+  \frametitle{%
+    \begin{tikzpicture}[remember picture, overlay]
+      \node[anchor=north east, xshift=-0.4cm, yshift=-0.4cm, text=black] at (current page.north east) {
+        \CategoryBadge[MicroColor!20]{Microservices}
+      };
+    \end{tikzpicture}
+    Answer \theqcounter: What is the Strangler Fig Pattern?%
+  }
+
+  {\footnotesize
+  The Strangler Fig Pattern incrementally replaces pieces of a monolith with microservices. A facade routes requests between legacy and new components until the monolith can be retired.
+  }
+
+  \begin{minted}[fontsize=\scriptsize]{csharp}
+// ASP.NET Core facade routing
+app.MapWhen(ctx => ctx.Request.Path.StartsWithSegments("/legacy"),
+    legacy => legacy.RunProxy("http://monolith"));
+app.Map("/orders", m => m.RunProxy("http://orders-service"));
+  \end{minted}
+\end{frame}
+
+% 5 – Event Sourcing
+\QuestionSlide[\CategoryBadge[MicroColor!20]{Microservices}]{** What is Event Sourcing?}
+
+\begin{frame}[fragile]
+  \frametitle{%
+    \begin{tikzpicture}[remember picture, overlay]
+      \node[anchor=north east, xshift=-0.4cm, yshift=-0.4cm, text=black] at (current page.north east) {
+        \CategoryBadge[MicroColor!20]{Microservices}
+      };
+    \end{tikzpicture}
+    Answer \theqcounter: What is Event Sourcing?%
+  }
+
+  {\footnotesize
+  Event Sourcing persists state as a sequence of immutable events. The current state is rebuilt by replaying events, enabling full audit history and temporal queries.
+  }
+
+  \begin{minted}[fontsize=\scriptsize]{csharp}
+public record FundsDeposited(Guid AccountId, decimal Amount);
+
+public class Account {
+    private decimal _balance;
+    public void Apply(FundsDeposited e) => _balance += e.Amount;
+}
+  \end{minted}
+\end{frame}

--- a/main.tex
+++ b/main.tex
@@ -54,8 +54,9 @@
     \TOCButtonTall{sec6}{sec6}{Entity Framework} \\[1em]
     \TOCButtonTall{sec7}{sec7}{Design Principles} &
     \TOCButtonTall{sec8}{sec8}{Design Patterns} \\[1em]
-    \TOCButtonTall{sec9}{sec9}{OAuth} 
-  \end{tabular} 
+    \TOCButtonTall{sec9}{sec9}{OAuth} &
+    \TOCButtonTall{sec10}{sec10}{Microservices}
+  \end{tabular}
 \end{frame}
 
 \hypertarget{sec1}{}
@@ -93,6 +94,10 @@
 \hypertarget{sec9}{}
 \section{OAuth}
 \input{areas/9-OAuth}
+
+\hypertarget{sec10}{}
+\section{Microservices}
+\input{areas/10-microservices}
 
 \begin{frame}
   \centering

--- a/mybeamer.cls
+++ b/mybeamer.cls
@@ -40,6 +40,7 @@
 \definecolor{LinqColor}{HTML}{8BC34A}
 \definecolor{CollColor}{HTML}{D81B60}
 \definecolor{AuthColor}{RGB}{155,89,182}
+\definecolor{MicroColor}{HTML}{009688}
 
 \definecolor{CodeBg}{HTML}{F8F8F8} 
 \definecolor{sec1bg}{HTML}{6BAED6}  % C# Beginner – MemoryColor
@@ -51,6 +52,7 @@
 \definecolor{sec7bg}{HTML}{FD8D3C}  % Design Principles – OOPColor
 \definecolor{sec8bg}{HTML}{795548}  % Design Patterns – ArchColor
 \definecolor{sec9bg}{HTML}{795548}  % Design Patterns – ArchColor
+\definecolor{sec10bg}{HTML}{009688} % Microservices – MicroColor
 
 \setbeamercolor{sec1}{fg=white,bg=sec1bg}
 \setbeamercolor{sec2}{fg=white,bg=sec2bg}
@@ -61,6 +63,7 @@
 \setbeamercolor{sec7}{fg=white,bg=sec7bg}
 \setbeamercolor{sec8}{fg=white,bg=sec8bg}
 \setbeamercolor{sec9}{fg=white,bg=sec9bg}
+\setbeamercolor{sec10}{fg=white,bg=sec10bg}
 
 \lstset{
   basicstyle=\tiny\ttfamily,


### PR DESCRIPTION
## Summary
- add Microservices deck with bulkhead, sidecar, service mesh, strangler fig, and event sourcing cards
- wire new Microservices section into the table of contents and color scheme
- document new area file in repository structure

## Testing
- `pdflatex -shell-escape -interaction=nonstopmode main.tex` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689eda75b66c832987888f556c05eeb7