### PR TITLE
Add Advanced Cloud & Leadership section on handling poison messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/konradcinkusz/csharp-flashcards/actions/workflows/ci.yml/badge.svg)](https://github.com/konradcinkusz/csharp-flashcards/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Beamer slide deck of **Q-and-A flash-cards** that cover C# language basics, LINQ, async/await, Entity Framework, design principles and patterns.  
+A Beamer slide deck of **Q-and-A flash-cards** that cover C# language basics, LINQ, async/await, Entity Framework, design principles and patterns, plus advanced cloud and leadership topics.
 Use it for live classes, self-study, interview prep, or conference lightning talks.
 
 ---
@@ -43,7 +43,8 @@ Prefer a browser? Import the repo into Overleaf and press *Re-compile* – Overl
 │   ├── design-principles.tex
 │   ├── design-patterns.tex
 │   ├── entity-framework.tex
-│   └── linq.tex
+│   ├── linq.tex
+│   └── advanced-cloud-leadership.tex
 ├── main.tex
 ├── mybeamer.cls / mybeamer.sty
 └── .github/workflows/ci.yml

--- a/areas/10-advanced-cloud-leadership.tex
+++ b/areas/10-advanced-cloud-leadership.tex
@@ -1,0 +1,22 @@
+% 1 --- Handling poison messages in Azure Service Bus
+\QuestionSlide[\CategoryBadge[AuthColor!20]{Cloud}]{*** How do you handle poison messages in Azure Service Bus queues?}
+\begin{frame}[fragile]
+  \frametitle{
+    \begin{tikzpicture}[remember picture,overlay]
+      \node[anchor=north east,xshift=-0.4cm,yshift=-0.4cm] at (current page.north east) {
+        \CategoryBadge[AuthColor!20]{Cloud}
+      };
+    \end{tikzpicture}
+
+    Answer \theqcounter: *** How do you handle poison messages in Azure Service Bus queues?%
+  }
+
+  {\footnotesize
+  \begin{itemize}
+    \item \textbf{Detect} when a message exceeds \texttt{maxDeliveryCount}; Service Bus moves it to the dead-letter queue.
+    \item \textbf{Process} the DLQ with a separate worker that logs and decides whether to fix or discard the payload.
+    \item \textbf{Mitigate} with exponential back-off retries and idempotent handlers to avoid repeats.
+    \item \textbf{Prevent} by validating input early and monitoring \texttt{DeadLetterMessageCount}.
+  \end{itemize}
+  }
+\end{frame}

--- a/main.tex
+++ b/main.tex
@@ -54,8 +54,9 @@
     \TOCButtonTall{sec6}{sec6}{Entity Framework} \\[1em]
     \TOCButtonTall{sec7}{sec7}{Design Principles} &
     \TOCButtonTall{sec8}{sec8}{Design Patterns} \\[1em]
-    \TOCButtonTall{sec9}{sec9}{OAuth} 
-  \end{tabular} 
+    \TOCButtonTall{sec9}{sec9}{OAuth} &
+    \TOCButtonTall{sec10}{sec10}{Advanced Cloud\\& Leadership}
+  \end{tabular}
 \end{frame}
 
 \hypertarget{sec1}{}
@@ -93,6 +94,10 @@
 \hypertarget{sec9}{}
 \section{OAuth}
 \input{areas/9-OAuth}
+
+\hypertarget{sec10}{}
+\section{Advanced Cloud \& Leadership}
+\input{areas/10-advanced-cloud-leadership}
 
 \begin{frame}
   \centering

--- a/mybeamer.cls
+++ b/mybeamer.cls
@@ -51,6 +51,7 @@
 \definecolor{sec7bg}{HTML}{FD8D3C}  % Design Principles – OOPColor
 \definecolor{sec8bg}{HTML}{795548}  % Design Patterns – ArchColor
 \definecolor{sec9bg}{HTML}{795548}  % Design Patterns – ArchColor
+\definecolor{sec10bg}{HTML}{9B59B6} % Advanced Cloud & Leadership – AuthColor
 
 \setbeamercolor{sec1}{fg=white,bg=sec1bg}
 \setbeamercolor{sec2}{fg=white,bg=sec2bg}
@@ -61,6 +62,7 @@
 \setbeamercolor{sec7}{fg=white,bg=sec7bg}
 \setbeamercolor{sec8}{fg=white,bg=sec8bg}
 \setbeamercolor{sec9}{fg=white,bg=sec9bg}
+\setbeamercolor{sec10}{fg=white,bg=sec10bg}
 
 \lstset{
   basicstyle=\tiny\ttfamily,


### PR DESCRIPTION
## Summary
- add Advanced Cloud & Leadership section with flashcard on handling poison messages in Azure Service Bus queues
- extend Beamer style and table of contents to support the new section
- document new coverage and file in README

## Testing
- `pdflatex -interaction=nonstopmode -halt-on-error main.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689edacbc07c8329a12fec054c515097